### PR TITLE
strongly type `options` param in `parseTOML` and `parseForESLint`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { traverseNodes } from "./traverse"
 import { getStaticTOMLValue } from "./utils"
 import { KEYS } from "./visitor-keys"
 import { ParseError } from "./errors"
+import type { ParserOptions } from "./parser-options"
 
 export { AST, ParseError }
 
@@ -19,6 +20,9 @@ export { traverseNodes, getStaticTOMLValue }
 /**
  * Parse TOML source code
  */
-export function parseTOML(code: string, options?: any): AST.TOMLProgram {
+export function parseTOML(
+    code: string,
+    options?: ParserOptions,
+): AST.TOMLProgram {
     return parseForESLint(code, options).ast
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,12 +2,13 @@ import { TOMLParser } from "./toml-parser"
 import type { SourceCode } from "eslint"
 import { KEYS } from "./visitor-keys"
 import type { TOMLProgram } from "./ast"
+import type { ParserOptions } from "./parser-options"
 /**
  * Parse source code
  */
 export function parseForESLint(
     code: string,
-    options?: any,
+    options?: ParserOptions,
 ): {
     ast: TOMLProgram
     visitorKeys: SourceCode.VisitorKeys


### PR DESCRIPTION
Since `options` gets passed straight through, I figure it makes sense to strongly type it to indicate what will actually have an effect on parsing.